### PR TITLE
Interpretations docs update

### DIFF
--- a/docs/developer-reference/_category_.json
+++ b/docs/developer-reference/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Developer Reference",
+  "position": 9,
+  "link": {
+    "type": "generated-index",
+    "description": "Developer reference for Nodestream"
+  }
+}

--- a/docs/developer-reference/interpreting.md
+++ b/docs/developer-reference/interpreting.md
@@ -1,0 +1,44 @@
+# Interpretations
+
+# Sequence Diagram
+In the diagram some details are skipped to keep the picture clean.
+`Pipeline` is an abstraction for all the things happening before Interpreter step. Similarly `Writer` is included
+to show where the product of interpretation is consumed. Read the narrative for 
+additional details.
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant I as Interpreter
+    participant C as ProviderContext
+    participant Int as Interpretation
+    participant D as DesiredIngestion
+    participant W as Writer
+    participant S as IngestionStrategy
+
+    P->>I: init(interpretations)
+    P->>W: init(IngestionStrategy)
+    P->>I: handle_async_record_stream
+    I->>I: interpret record from stream
+    I->>C: fresh(record)
+    Note over C: DesiredIngestion Created
+    C->>I: context
+    I->>Int: interpret(context)
+    I->>D: add_source_node()
+    I->>D: add_relationship()
+    I->>P: desired_ingestion
+    P->>W: write_record(desired_ingestion)
+    W->>D: ingest(IngestionStrategy)
+    D->>S: ingest_source_node
+    D->>S: ingest_relationship 
+```
+
+Narrative for the above diagram:
+1. When a pipeline with `Interpreter` step starts up, it initializes `Interpreter` with interpretations from the pipeline YAML file
+2. It also adds the `Writer` step based on targets specified in nodestream.yaml
+3. `Interpreter` will handle a record stream from the pipeline and start interpreting each record
+4. It starts out by creating a context with a blank `DesiredIngestion`
+5. It then feeds the `DesiredIngestion` into every interpretation specified in the pipeline YAML file.
+6. The most common interpretation is the `SourceNodeInterpretation`, and it adds a source `Node` to the `DesiredIngestion`
+7. A `RelationshipInterpretation` adds a `RelationshipWithNodes` to the `DesiredIngestion`
+8. The Interpreter then yields the DesiredIngestion to the pipeline.
+9. At the end of the pipeline the `Writer` step processes the `DesiredIngestion` using the configured `IngestionStrategy`

--- a/docs/reference/interpreting.md
+++ b/docs/reference/interpreting.md
@@ -23,13 +23,14 @@ Interpretations are the building blocks of the `Interpreter`. They are used to i
 The `SourceNodeInterpretation` is used to interpret the data into a source node.
 
 | Parameter Name     | Required? | Type                    | Description                                                                                                                                                                                                                                                                                                            |
-| ------------------ | --------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------|-----------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | node_type          | Yes       | String or ValueProvider | Specifies the type of the source node. It is a required field. When a  ValueProvider is used dynamic index creation and schema introspection are not supported.                                                                                                                                                        |
 | key                | Yes       | Dictionary              | Contains key-value pairs that define the key of the source node.  The keys represent field names, and the values can be either static values or value providers.  It is a required field.                                                                                                                              |
+| allow_create       | No        | Boolean                 | When `true`, allows creating new nodes when source node is not in the graph. When `false`, new source nodes will not be added to the graph. This field is optional and the default value is `true`.                                                                                                                    |
 | properties         | No        | Dictionary              | Stores additional properties of the source node. It is a dictionary  where the keys represent property names, and the values can be either  static values or value providers. This field is optional.                                                                                                                  |
 | additional_indexes | No        | List[String]            | Specifies additional indexes for desired on the source node. It is a list of field names. This field is optional.                                                                                                                                                                                                      |
 | additional_types   | No        | List[String]            | Defines additional types for the source node. It is a list of strings representing the additional types.  These types are not considered by ingestion system as part of the identity of the node and rather considered as  extra labels applied after the ingestion of the node is completed.  This field is optional. |
-| normalization      | No        | Dictionary              | Contains normalization flags that should be adopted by value providers when getting values. This field is optional. [See the normalization reference](#normalizers).  By default `do_lowercase_strings` is enabled.                                                                                                |
+| normalization      | No        | Dictionary              | Contains normalization flags that should be adopted by value providers when getting values. This field is optional. [See the normalization reference](#normalizers).  By default `do_lowercase_strings` is enabled.                                                                                                    |       
 
 #### Example
 
@@ -76,6 +77,8 @@ The `SourceNodeInterpretation` is used to interpret the data into a source node.
   node_key:
     name: !jmespath name
 ```
+
+See Also: [Source Node and Relationship Interpretation Combined](#source-node-and-relationship-interpretation-combined)
 
 ### Properties Interpretation
 
@@ -367,3 +370,109 @@ The following interpretation would create a `Locality` node with the keys of `Ne
             data: !jmespath city
           state: !jmespath state
 ```
+
+### Source Node and Relationship Interpretation Combined
+A common use case is to combine source node and relationship interpretation. 
+```yaml
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    interpretations:
+    - type: source_node
+      node_type: Person
+      key:
+        name: !jmespath name
+      allow_create: true
+    - type: relationship
+      node_type: Person
+      relationship_type: HAS_CHILD
+      node_creation_rule: MATCH_ONLY
+      iterate_on: !jmespath children[*]
+      node_key:
+        name: !jmespath name
+```
+In this example, `source_node` has the flag `allow_create=true` while the 
+relationship has `node_creation_rule=MATCH_ONLY`. This means `Person` 
+nodes will be created if they don't already exist using the `source_node` interpretation,
+but the children `Person` nodes will not be created as part of the `relationship` interpretation. 
+The `relationship` interpretation will only create the relationships between existing persons.
+
+
+Below is a comprehensive list of possible behaviors depending on pipeline configuration and graph state:
+
+#### Given: Source node does not exist in the graph
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2"></th>
+      <th rowspan="2"></th>
+      <th colspan="2">Related Node</th>
+    </tr>
+    <tr>
+      <th>Already Exists</th>
+      <th>Does Not Exist</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">source_node.allow_create=true</td>
+      <td>relationship.node_creation_rule=EAGER</td>
+      <td>Source Node and Relationship are created</td>
+      <td>Everything is created</td>
+    </tr>
+    <tr>
+      <td>relationship.node_creation_rule=MATCH_ONLY</td>
+      <td>Source Node and Relationship are created</td>
+      <td>Source Node is created</td>
+    </tr>
+    <tr>
+      <td rowspan="2">source_node.allow_create=false</td>
+      <td>relationship.node_creation_rule=EAGER</td>
+      <td>Nothing is created</td>
+      <td>Related node is created</td>
+    </tr>
+    <tr>
+      <td>relationship.node_creation_rule=MATCH_ONLY</td>
+      <td>Nothing is created</td>
+      <td>Nothing is created</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Given: Source node already exists in the graph
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2"></th>
+      <th rowspan="2"></th>
+      <th colspan="2">Related Node</th>
+    </tr>
+    <tr>
+      <th>Already Exists</th>
+      <th>Does Not Exist</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">source_node.allow_create=true</td>
+      <td>relationship.node_creation_rule=EAGER</td>
+      <td>Relationship is created</td>
+      <td>Related Node and Relationship are created</td>
+    </tr>
+    <tr>
+      <td>relationship.node_creation_rule=MATCH_ONLY</td>
+      <td>Relationship is created</td>
+      <td>Nothing is created</td>
+    </tr>
+    <tr>
+      <td rowspan="2">source_node.allow_create=false</td>
+      <td>relationship.node_creation_rule=EAGER</td>
+      <td>Relationship is created</td>
+      <td>Related Node and Relationship are created</td>
+    </tr>
+    <tr>
+      <td>relationship.node_creation_rule=MATCH_ONLY</td>
+      <td>Relationship is created</td>
+      <td>Nothing is created</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/tutorial-basics/create-a-new-pipeline.md
+++ b/docs/tutorial-basics/create-a-new-pipeline.md
@@ -130,8 +130,8 @@ The first interpretation is a `source_node` interpretation that describes how to
 ```
 
 A source node represents the node at the conceptual "center" of the ingest. 
-Typically this represents the central entity that you are modeling with the Ingest. 
-In our case, its the employee for whom the record represents. 
+Typically, this represents the central entity that you are modeling with the Ingest. 
+In our case, it's the employee for whom the record represents. 
 We've decided to call this type of node an `Employee`.
 
 The `key` block tells nodestream what set of properties represents a unique node of the `node_type` and how to get the values. 
@@ -139,6 +139,8 @@ In our case, we use the employee_id field the record and extract that using the 
 
 We take a similar approach with the properties field. We extract the `name` property.
 Note that we have kept the field names on the node the same as the CSV document, but this does not need to be the case.
+
+See Also: [Reference documentation for source node interpretation](../reference/interpreting.md#source-node-interpretation)
 
 ### Relationship Interpretation
 
@@ -156,6 +158,9 @@ In our case, we want to model the org chart, so we need to draw the relationship
 Here we tell the interpreter that we want to relate to an `Employee` to our source node with a relationship type of `REPORTS_TO`. 
 For nodestream to know which `Employee` node to relate to, we need to specify the key of the related node. 
 In our case, we can do that by extracting the value of `manager_id` and mapping it to the `employee_id` key of the related node.
+
+See Also: [Reference documentation for relationship interpretation](../reference/interpreting.md#relationship-interpretation)
+
 
 ## Next Steps
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "3.1.1",
     "@docusaurus/preset-classic": "3.1.1",
-    "@docusaurus/theme-mermaid": "^3.1.1",
+    "@docusaurus/theme-mermaid": "3.1.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",


### PR DESCRIPTION
This document update is for the new `allow_create` flag that was added to source node interpretation.
Also documents the interaction between SourceNodeInterpretation and RelationshipNodeInterpretation as it pertains to `source.allow_create` and `relationship.node_creation_rule`.

Also includes a Developer Reference for Interpreting.